### PR TITLE
CMakeLists: remove CATKIN_DEPENDS parameter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,13 +14,7 @@ find_package(
 find_package(
             LibEPOS2 NO_MODULE REQUIRED)
 
-catkin_package(
-    CATKIN_DEPENDS
-             roscpp
-             sensor_msgs
-             geometry_msgs
-             nav_msgs
-             tf)
+catkin_package()
 
 include(${LIBEPOS2_USE_FILE})
 


### PR DESCRIPTION
Since we don't install any headers, we don't have to use the CATKIN_DEPENDS
parameter.

Also see:
http://answers.ros.org/question/58498/what-is-the-purpose-of-catkin_depends/#58593
